### PR TITLE
Support ** exponent syntax in xacro expressions

### DIFF
--- a/src/xacro_parser_instance.ts
+++ b/src/xacro_parser_instance.ts
@@ -11,6 +11,54 @@ export function isNumber(str) {
     return !isNaN(Number(str)) && !isNaN(parseFloat(str));
 }
 import { Parser } from "expr-eval";
+
+function normalizeExponentOperator(expression: string): string {
+    let normalized = "";
+    let quote: string | null = null;
+    let escaped = false;
+
+    for (let i = 0; i < expression.length; i++) {
+        const char = expression[i];
+        const nextChar = expression[i + 1];
+
+        if (quote !== null) {
+            normalized += char;
+
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+
+            if (char === "\\") {
+                escaped = true;
+                continue;
+            }
+
+            if (char === quote) {
+                quote = null;
+            }
+
+            continue;
+        }
+
+        if (char === "'" || char === '"' || char === "`") {
+            quote = char;
+            normalized += char;
+            continue;
+        }
+
+        if (char === "*" && nextChar === "*") {
+            normalized += "^";
+            i++;
+            continue;
+        }
+
+        normalized += char;
+    }
+
+    return normalized;
+}
+
 class ExpressionParser extends Parser {
     constructor(...args) {
         super(...args);
@@ -256,6 +304,11 @@ class ExpressionParser extends Parser {
             nan: NaN,
             tau: Math.PI * 2,
         };
+    }
+
+    evaluate(expr, values) {
+        const normalizedExpr = normalizeExponentOperator(expr);
+        return super.evaluate(normalizedExpr, values);
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"module": "ES2020",
 		"moduleResolution": "Node",
+		"ignoreDeprecations": "5.0",
 		"target": "ES6",
 		"lib": [
 			"ES6",


### PR DESCRIPTION
## Summary
- add a preprocessing step in the custom xacro expression parser to normalize `**` to `^` before evaluation
- preserve backward compatibility by keeping existing `^` exponent behavior unchanged
- avoid rewriting string literals while normalizing, so quoted text containing `**` remains intact

## Why
`expr-eval` in this extension supports `^` for exponentiation but does not parse `**`. Many xacro users expect Python-style `**`, so expressions like `${2**3}` currently fail. This change enables `**` while retaining existing behavior.

## Validation
- ran `npm run lint`
- ran `npm run compile` (build succeeds; existing webpack warnings about optional native deps are unchanged)